### PR TITLE
remove errant name with non-UTF-8 symbol

### DIFF
--- a/names.txt
+++ b/names.txt
@@ -817,7 +817,6 @@ Amund
 Amy
 Amyas
 Amye
-Am‚lie
 An
 Ana
 Anabal


### PR DESCRIPTION
This entry was causing the list to throw an error, assume it's a typo and suggest removing