### PR TITLE
Fix running-as-script check

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ random.last    = r(names)
 random.middle  = r(middle)
 random.place   = r(place)
 
-if(!module.parent) {
+if (require.main === module) {
   var l = process.argv[2] || 10
   while (l--)
     console.log(random.first(), '.', random.middle(), '.', random.last()


### PR DESCRIPTION
This library checks `!module.parent` to determine whether it is running as a script. When used in the [create-react-app](https://github.com/facebookincubator/create-react-app) webpack environment, `module.parent` is not set as expected, either via `import` or `require`. The lack of value for `module.parent` causes spurious logging to the console in these React apps.

Per the [official Node module docs](https://nodejs.org/api/modules.html#modules_accessing_the_main_module), we should be checking `require.main === module` instead. This pull request does just that. With this change, the spurious console logs disappear.